### PR TITLE
HOTFIX+added notifications to other platforms (excluding win+linux for now), added back button to player...

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,4 +51,6 @@ Currently working on a simple backend using python to update a Cloud Firestore D
 
 ## Notes:
 
-There is no platform implementation for audio on Windows 10 and consequently, while the build will run, it will not play media. It has occurred to me that this is a somewhat crucial issue to solve for a podcast application.
+There is still no notifications solution for Windows in the build
+
+Notification support has also recently got better on just_audio, possibly to the degree that dropping better_player may be viable for targeting mobile (see above diatribe about stacked media players)

--- a/README.md
+++ b/README.md
@@ -37,11 +37,18 @@ Currently working on a simple backend using python to update a Cloud Firestore D
 * Add proper platform boilerplate, version numbering, icons, tab labels, etc
 
 # Tested on:
-<ul>
-<li>
-    Web
-</li>
+<ol>
 <li>    
     Android 11
 </li>
-</ul>
+<li>
+    Web
+</li>
+<li>
+    Windows 10
+</li>
+</ol>
+
+## Notes:
+
+There is no platform implementation for audio on Windows 10 and consequently, while the build will run, it will not play media. It has occurred to me that this is a somewhat crucial issue to solve for a podcast application.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Currently working on a simple backend using python to update a Cloud Firestore D
 
 # Other significant TODOs:
 
+* Add more caching (alternatively, roll back to a lighter weight version)
 * Add proper testing
 * finish frontend subscription stuff
 * Add proper platform boilerplate, version numbering, icons, tab labels, etc

--- a/lib/components/menu/menu_item.dart
+++ b/lib/components/menu/menu_item.dart
@@ -20,7 +20,9 @@ class PodcastMenuItem extends StatelessWidget {
             : Image.network(podcastInfo.rssFeed!.image!.url ?? _fallbackImage),
       ),
       title: Text(podcastInfo.rssItem!.title ?? "Missing title info"),
-      subtitle: Text(podcastInfo.rssItem!.author ?? "Missing publishing info"),
+      subtitle: Text(podcastInfo.rssItem != null
+          ? FeedAnalysisFunctions.authorFromItem(podcastInfo.rssItem!)
+          : "Missing Publisher Info"),
       trailing: Icon(Icons.play_arrow_rounded),
       onTap: () =>
           // _handlePodcastSelection(context)

--- a/lib/controllers/generic_player_controller.dart
+++ b/lib/controllers/generic_player_controller.dart
@@ -25,6 +25,7 @@ class GenericController with ChangeNotifier {
 
   void setContext(BuildContext context) => this.context = context;
 
+  /// get the controller type returned for this category of device
   AudioPlayerTypes get podcastController => AudioPlayerTypes();
   bool get isInitialized => false;
 

--- a/lib/controllers/mobile_player_controller.dart
+++ b/lib/controllers/mobile_player_controller.dart
@@ -68,7 +68,7 @@ class MobilePlayerController extends GenericController {
 
     String audioSrc = rssItem.enclosure!.url!;
     String? trackTitle = rssItem.title;
-    String? trackAuthor = rssItem.author;
+    String? trackAuthor = FeedAnalysisFunctions.authorFromItem(rssItem);
     String? trackImage = FeedAnalysisFunctions.imageFromPodcastInfo(
         PodcastInfo(rssFeed: this.currentFeed, rssItem: this.currentTrack));
     // if (rssItem.itunes != null) {

--- a/lib/controllers/podcast_stream.dart
+++ b/lib/controllers/podcast_stream.dart
@@ -189,7 +189,7 @@ class Podcast with ChangeNotifier {
       : null;
   set selectedItem(PodcastInfo? value) {
     this._exploreViewModel!.selectedItem = value;
-    this._subscriptionViewModel!.selectedItem = value;
+    this._subscriptionViewModel?.selectedItem = value;
     notifyListeners();
   }
 

--- a/lib/controllers/web_player_controller.dart
+++ b/lib/controllers/web_player_controller.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter_podcast_app/constants/images_resources.dart';
 import 'package:flutter_podcast_app/controllers/generic_player_controller.dart';
+import 'package:flutter_podcast_app/functions/feed_analysis.dart';
 import 'package:flutter_podcast_app/models/audio_player_types.dart';
 import 'package:just_audio/just_audio.dart';
 import 'package:just_audio_background/just_audio_background.dart';
@@ -63,9 +64,10 @@ class WebPlayerController extends GenericController {
         tag: MediaItem(
           id: audioSrc,
           title: rssItem.title ?? "No Title Given",
-          album: rssItem.itunes != null
-              ? rssItem.itunes!.author ?? "No Author Given"
-              : "No Author Found",
+          album: this.currentFeed != null
+              ? this.currentFeed!.title ?? "Podcast Name Not Found"
+              : FeedAnalysisFunctions.authorFromItem(rssItem),
+          artist: FeedAnalysisFunctions.authorFromItem(rssItem),
           artUri: Uri.parse(
               rssItem.itunes != null && rssItem.itunes!.image != null
                   ? rssItem.itunes!.image!.href ?? ImgResources.fallbackImgUri

--- a/lib/controllers/web_player_controller.dart
+++ b/lib/controllers/web_player_controller.dart
@@ -4,6 +4,7 @@ import 'package:flutter_podcast_app/constants/images_resources.dart';
 import 'package:flutter_podcast_app/controllers/generic_player_controller.dart';
 import 'package:flutter_podcast_app/functions/feed_analysis.dart';
 import 'package:flutter_podcast_app/models/audio_player_types.dart';
+import 'package:flutter_podcast_app/models/podcast_info.dart';
 import 'package:just_audio/just_audio.dart';
 import 'package:just_audio_background/just_audio_background.dart';
 import 'package:webfeed/domain/rss_item.dart';
@@ -68,10 +69,9 @@ class WebPlayerController extends GenericController {
               ? this.currentFeed!.title ?? "Podcast Name Not Found"
               : FeedAnalysisFunctions.authorFromItem(rssItem),
           artist: FeedAnalysisFunctions.authorFromItem(rssItem),
-          artUri: Uri.parse(
-              rssItem.itunes != null && rssItem.itunes!.image != null
-                  ? rssItem.itunes!.image!.href ?? ImgResources.fallbackImgUri
-                  : ImgResources.fallbackImgUri),
+          artUri: Uri.parse(FeedAnalysisFunctions.imageFromPodcastInfo(
+              PodcastInfo(
+                  rssFeed: this.currentFeed, rssItem: this.currentTrack))),
         )));
   }
 

--- a/lib/controllers/web_player_controller.dart
+++ b/lib/controllers/web_player_controller.dart
@@ -1,8 +1,10 @@
 import 'dart:async';
 
+import 'package:flutter_podcast_app/constants/images_resources.dart';
 import 'package:flutter_podcast_app/controllers/generic_player_controller.dart';
 import 'package:flutter_podcast_app/models/audio_player_types.dart';
 import 'package:just_audio/just_audio.dart';
+import 'package:just_audio_background/just_audio_background.dart';
 import 'package:webfeed/domain/rss_item.dart';
 
 class WebPlayerController extends GenericController {
@@ -56,7 +58,19 @@ class WebPlayerController extends GenericController {
   set currentTrack(RssItem rssItem) {
     super.currentTrack = rssItem;
     String audioSrc = rssItem.enclosure!.url!;
-    _webController.setUrl(audioSrc);
+    // _webController.setUrl(audioSrc);
+    _webController.setAudioSource(AudioSource.uri(Uri.parse(audioSrc),
+        tag: MediaItem(
+          id: audioSrc,
+          title: rssItem.title ?? "No Title Given",
+          album: rssItem.itunes != null
+              ? rssItem.itunes!.author ?? "No Author Given"
+              : "No Author Found",
+          artUri: Uri.parse(
+              rssItem.itunes != null && rssItem.itunes!.image != null
+                  ? rssItem.itunes!.image!.href ?? ImgResources.fallbackImgUri
+                  : ImgResources.fallbackImgUri),
+        )));
   }
 
   @override

--- a/lib/functions/feed_analysis.dart
+++ b/lib/functions/feed_analysis.dart
@@ -6,6 +6,16 @@ import 'package:webfeed/domain/rss_feed.dart';
 import 'package:webfeed/domain/rss_item.dart';
 
 class FeedAnalysisFunctions {
+  static String authorFromItem(RssItem rssItem) {
+    if (rssItem.itunes != null) {
+      return rssItem.itunes!.author ??
+          // rssItem.itunes!.subtitle ??
+          rssItem.author ??
+          "Missing Publisher Info";
+    }
+    return rssItem.author ?? "Missing Publisher Info";
+  }
+
   static bool hasIndividualEpisodeImage(RssItem rssItem) {
     if (rssItem.itunes != null) {
       if (rssItem.itunes!.image != null) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:flutter_podcast_app/controllers/podcast_stream.dart';
 import 'package:flutter_podcast_app/services/color_service.dart';
 import 'package:flutter_podcast_app/services/database_manager.dart';
 import 'package:flutter_podcast_app/services/state_trackers.dart';
+import 'package:just_audio_background/just_audio_background.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -13,6 +14,11 @@ Future<void> main() async {
   // SystemChrome.setSystemUIOverlayStyle(SystemUiOverlayStyle.light);
   WidgetsFlutterBinding.ensureInitialized();
   SharedPreferences prefs = await SharedPreferences.getInstance();
+  await JustAudioBackground.init(
+    androidNotificationChannelId: 'com.ryanheise.bg_demo.channel.audio',
+    androidNotificationChannelName: 'Audio playback',
+    androidNotificationOngoing: true,
+  );
   runApp(MyApp(
     prefs: prefs,
   ));

--- a/lib/screens/podcast_player.dart
+++ b/lib/screens/podcast_player.dart
@@ -18,6 +18,11 @@ class PodcastPlayer extends StatelessWidget {
     }
     return SafeArea(
         child: Scaffold(
+      appBar: AppBar(
+        elevation: 0,
+        backgroundColor: Theme.of(context).colorScheme.surface,
+        iconTheme: IconThemeData(color: Theme.of(context).colorScheme.primary),
+      ),
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.spaceEvenly,

--- a/lib/screens/podcast_player.dart
+++ b/lib/screens/podcast_player.dart
@@ -1,3 +1,4 @@
+import 'package:beamer/beamer.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_podcast_app/components/controls_row.dart';
 import 'package:flutter_podcast_app/components/podcast_img.dart';
@@ -13,7 +14,11 @@ class PodcastPlayer extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (context.read<Podcast>().podcastViewModel == null) {
-      Navigator.pushNamed(context, '/');
+      Beamer.of(context).beamToNamed('/');
+      return Text("No Podcast Episode Selected");
+    }
+    if (context.read<Podcast>().podcastViewModel?.selectedItem == null) {
+      Beamer.of(context).beamToNamed('/');
       return Text("No Podcast Episode Selected");
     }
     return SafeArea(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       name: better_player
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.79"
+    version: "0.0.81"
   boolean_selector:
     dependency: transitive
     description:
@@ -127,7 +127,14 @@ packages:
       name: flutter_widget_from_html_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.0"
+    version: "0.8.4"
+  fwfh_text_style:
+    dependency: transitive
+    description:
+      name: fwfh_text_style
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.7.3+1"
   html:
     dependency: transitive
     description:
@@ -183,7 +190,7 @@ packages:
       name: just_audio_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.3"
   matcher:
     dependency: transitive
     description:
@@ -191,6 +198,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -225,14 +239,14 @@ packages:
       name: path_provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.7"
+    version: "2.0.8"
   path_provider_android:
     dependency: transitive
     description:
       name: path_provider_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.9"
+    version: "2.0.11"
   path_provider_ios:
     dependency: transitive
     description:
@@ -246,35 +260,28 @@ packages:
       name: path_provider_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.5"
   path_provider_macos:
     dependency: transitive
     description:
       name: path_provider_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.5"
   path_provider_platform_interface:
     dependency: transitive
     description:
       name: path_provider_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.3"
   path_provider_windows:
     dependency: transitive
     description:
       name: path_provider_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.4"
-  pedantic:
-    dependency: transitive
-    description:
-      name: pedantic
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.11.1"
+    version: "2.0.5"
   petitparser:
     dependency: transitive
     description:
@@ -288,14 +295,14 @@ packages:
       name: platform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.2"
+    version: "3.1.0"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.1.2"
   process:
     dependency: transitive
     description:
@@ -309,7 +316,7 @@ packages:
       name: provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.1"
+    version: "6.0.2"
   rxdart:
     dependency: transitive
     description:
@@ -323,28 +330,28 @@ packages:
       name: shared_preferences
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.9"
+    version: "2.0.12"
   shared_preferences_android:
     dependency: transitive
     description:
       name: shared_preferences_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.9"
+    version: "2.0.10"
   shared_preferences_ios:
     dependency: transitive
     description:
       name: shared_preferences_ios
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.0.9"
   shared_preferences_linux:
     dependency: transitive
     description:
       name: shared_preferences_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.4"
   shared_preferences_macos:
     dependency: transitive
     description:
@@ -365,14 +372,14 @@ packages:
       name: shared_preferences_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.3"
   shared_preferences_windows:
     dependency: transitive
     description:
       name: shared_preferences_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.4"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -419,7 +426,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.8"
   typed_data:
     dependency: transitive
     description:
@@ -433,35 +440,49 @@ packages:
       name: url_launcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.15"
+    version: "6.0.18"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.0.14"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.0.14"
   url_launcher_linux:
     dependency: transitive
     description:
       name: url_launcher_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.3"
   url_launcher_macos:
     dependency: transitive
     description:
       name: url_launcher_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.3"
   url_launcher_platform_interface:
     dependency: transitive
     description:
       name: url_launcher_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.4"
+    version: "2.0.5"
   url_launcher_web:
     dependency: transitive
     description:
       name: url_launcher_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.4"
+    version: "2.0.6"
   url_launcher_windows:
     dependency: transitive
     description:
@@ -538,14 +559,14 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.1"
+    version: "2.3.10"
   xdg_directories:
     dependency: transitive
     description:
       name: xdg_directories
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
+    version: "0.2.0+1"
   xml:
     dependency: transitive
     description:
@@ -554,5 +575,5 @@ packages:
     source: hosted
     version: "5.3.1"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
-  flutter: ">=2.5.0"
+  dart: ">=2.15.0 <3.0.0"
+  flutter: ">=2.6.0-0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -177,6 +177,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.9.18"
+  just_audio_libwinmedia:
+    dependency: "direct main"
+    description:
+      name: just_audio_libwinmedia
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.4"
   just_audio_platform_interface:
     dependency: transitive
     description:
@@ -191,6 +198,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.4.3"
+  libwinmedia:
+    dependency: transitive
+    description:
+      name: libwinmedia
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.7"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -8,6 +8,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.8.2"
+  audio_service:
+    dependency: transitive
+    description:
+      name: audio_service
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.18.3"
+  audio_service_platform_interface:
+    dependency: transitive
+    description:
+      name: audio_service_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.0"
+  audio_service_web:
+    dependency: transitive
+    description:
+      name: audio_service_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.1"
   audio_session:
     dependency: transitive
     description:
@@ -111,6 +132,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_cache_manager:
+    dependency: transitive
+    description:
+      name: flutter_cache_manager
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.3.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -177,6 +205,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.9.18"
+  just_audio_background:
+    dependency: "direct main"
+    description:
+      name: just_audio_background
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.1-beta.4"
   just_audio_libwinmedia:
     dependency: "direct main"
     description:
@@ -190,7 +225,7 @@ packages:
       name: just_audio_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.0"
+    version: "4.1.0"
   just_audio_web:
     dependency: transitive
     description:
@@ -296,6 +331,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.5"
+  pedantic:
+    dependency: transitive
+    description:
+      name: pedantic
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.11.1"
   petitparser:
     dependency: transitive
     description:
@@ -406,6 +448,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.1"
+  sqflite:
+    dependency: transitive
+    description:
+      name: sqflite
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.2"
+  sqflite_common:
+    dependency: transitive
+    description:
+      name: sqflite_common
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.2.0"
   stack_trace:
     dependency: transitive
     description:
@@ -427,6 +483,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
+  synchronized:
+    dependency: transitive
+    description:
+      name: synchronized
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.0"
   term_glyph:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
 
   # audioplayers: ^0.19.1 # seems to have some issues on web
   just_audio: ^0.9.17
+  just_audio_libwinmedia: ^0.0.4  # endorsed by just_audio project for targeting win+linux
   
   http: ^0.13.1
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,9 +37,11 @@ dependencies:
            # not sure how that affects null safety
 
   # audioplayers: ^0.19.1 # seems to have some issues on web
+  # probably the widest device type support:
   just_audio: ^0.9.17
   just_audio_libwinmedia: ^0.0.4  # endorsed by just_audio project for targeting win+linux
-  
+  just_audio_background: ^0.0.1-beta.4  # support for simpler notification setup
+
   http: ^0.13.1
 
   better_player: ^0.0.79  # the best flutter based media player - breaks on android for a lot of versions tho

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,9 +6,12 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <libwinmedia/libwinmedia_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  LibwinmediaPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("LibwinmediaPlugin"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  libwinmedia
   url_launcher_windows
 )
 


### PR DESCRIPTION
...for the case where OSes like Windows have no system trigger for back track navigation

Also, minor fixes.

# Hotfix!
Finally <i>noticed</i> critical error where playing an item before adding subscriptions would fail because the app tries to set playing item on both explore and subscriptions view models.
*The fix simply adds the appropriate null check
*TODO: add a mechanism that adds playing item to new viewmodels once their creation _is_ triggered